### PR TITLE
enforced that XLEN divides nxc (issue #10)

### DIFF
--- a/grids/Grid3DCU.h
+++ b/grids/Grid3DCU.h
@@ -167,6 +167,23 @@ private:
 };
 /** constructor */
 inline Grid3DCU::Grid3DCU(CollectiveIO * col, VirtualTopology3D * vct) {
+  int get_rank();
+  if(!get_rank())
+  {
+    fflush(stdout);
+    bool xerror = false;
+    bool yerror = false;
+    bool zerror = false;
+    if((col->getNxc()) % (vct->getXLEN())) xerror=true;
+    if((col->getNyc()) % (vct->getYLEN())) yerror=true;
+    if((col->getNzc()) % (vct->getZLEN())) zerror=true;
+    if(xerror) printf("!!!ERROR: XLEN=%d does not divide nxc=%d\n", vct->getXLEN(),col->getNxc());
+    if(yerror) printf("!!!ERROR: YLEN=%d does not divide nyc=%d\n", vct->getYLEN(),col->getNyc());
+    if(zerror) printf("!!!ERROR: ZLEN=%d does not divide nzc=%d\n", vct->getZLEN(),col->getNzc());
+    fflush(stdout);
+    bool error = xerror||yerror||zerror;
+    if(error) exit(1);
+  }
   // add 2 for the guard cells
   nxc = (col->getNxc()) / (vct->getXLEN()) + 2;
   nyc = (col->getNyc()) / (vct->getYLEN()) + 2;

--- a/iPIC3D.cpp
+++ b/iPIC3D.cpp
@@ -44,13 +44,15 @@ using std::cerr;
 using std::endl;
 using std::ofstream;
 
+MPIdata *mpi;
+int get_rank(){ return mpi->rank; }
 
 int main(int argc, char **argv) {
   // initialize MPI environment
   // nprocs = number of processors
   // myrank = rank of tha process*/
   int nprocs, myrank, mem_avail;
-  MPIdata *mpi = new MPIdata(&argc, &argv);
+  mpi = new MPIdata(&argc, &argv);
   nprocs = mpi->nprocs;
   myrank = mpi->rank;
 


### PR DESCRIPTION
This is a quick fix.  Maybe a better fix with a more specific error message will become appropriate when specifying XLEN is made to be be configurable rather than requiring recompilation.
